### PR TITLE
RCTL/RACCT Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ failure = "~0.1.1"
 libc = "~0.2.41"
 sysctl = "~0.2.0"
 nix= "^0.11.0"
+rctl = "0"
 
 [dev-dependencies]
 prettytable-rs = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ failure = "~0.1.1"
 libc = "~0.2.41"
 sysctl = "~0.2.0"
 nix= "^0.11.0"
-rctl = "0"
+rctl = "0.0.2"
 
 [dev-dependencies]
 prettytable-rs = "0.7.0"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,4 +1,5 @@
 extern crate jail;
+extern crate rctl;
 
 use std::process::Command;
 
@@ -44,6 +45,13 @@ fn main() {
 
     println!("output: {}", String::from_utf8_lossy(&output.stdout));
 
+    match running.racct_statistics() {
+        Ok(stats) => println!("Resource accounting statistics: {:#?}", stats),
+        Err(jail::JailError::RctlError(rctl::Error::InvalidKernelState(state))) => {
+            println!("Resource accounting is reported as {}", state)
+        }
+        Err(e) => println!("Other Error: {}", e),
+    };
     println!("jid before restart: {}", running.jid);
     let running = running.restart().unwrap();
     println!("jid after restart: {}", running.jid);

--- a/src/error.rs
+++ b/src/error.rs
@@ -68,6 +68,9 @@ pub enum JailError {
 
     #[fail(display = "RCTL Error: {}", _0)]
     RctlError(#[cause] rctl::Error),
+
+    #[fail(display = "Jail must have a name if RCTL limits are to be set")]
+    UnnamedButLimited,
 }
 
 impl JailError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use param;
+use rctl;
 use sysctl;
 
 use std::io;
@@ -64,6 +65,9 @@ pub enum JailError {
 
     #[fail(display = "Could not serialize value to bytes")]
     SerializeFailed,
+
+    #[fail(display = "RCTL Error: {}", _0)]
+    RctlError(#[cause] rctl::Error),
 }
 
 impl JailError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ pub use stopped::StoppedJail;
 pub mod param;
 pub mod process;
 
+#[cfg(test)]
+mod tests;
+
 /// Represents a running or stopped jail.
 #[cfg(target_os = "freebsd")]
 pub enum Jail {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,8 @@ extern crate bitflags;
 
 extern crate nix;
 
+extern crate rctl;
+
 use std::collections::HashMap;
 use std::convert;
 use std::net;

--- a/src/running.rs
+++ b/src/running.rs
@@ -244,7 +244,16 @@ impl RunningJail {
     /// running.kill();
     /// ```
     pub fn kill(self: RunningJail) -> Result<(), JailError> {
-        sys::jail_remove(self.jid).and_then(|_| Ok(()))
+        let name = self.name()?;
+        sys::jail_remove(self.jid)?;
+
+        // Tear down RCTL rules
+        if &name != "" {
+            let filter: rctl::Filter = rctl::Subject::jail_name(name).into();
+            filter.remove_rules().map_err(JailError::RctlError)?;
+        }
+
+        Ok(())
     }
 
     /// Create a StoppedJail from a RunningJail, while not consuming the
@@ -276,6 +285,22 @@ impl RunningJail {
         stopped.hostname = self.hostname().ok();
         stopped.ips = self.ips()?;
         stopped.params = self.params()?;
+
+        // Save RCTL rules
+        let name = self.name();
+
+        if let Ok(name) = name {
+            let filter: rctl::Filter = rctl::Subject::jail_name(name).into();
+            for rctl::Rule {
+                subject: _,
+                resource,
+                limit,
+                action,
+            } in filter.rules().map_err(JailError::RctlError)?.into_iter()
+            {
+                stopped.limits.push((resource, limit, action));
+            }
+        }
 
         Ok(stopped)
     }

--- a/src/running.rs
+++ b/src/running.rs
@@ -1,4 +1,5 @@
 use param;
+use rctl;
 use sys;
 use JailError;
 use StoppedJail;
@@ -356,6 +357,31 @@ impl RunningJail {
     /// ```
     pub fn all() -> RunningJails {
         RunningJails::default()
+    }
+
+    /// Get the `RCTL` / `RACCT` usage statistics for this jail.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use jail::{StoppedJail, JailError};
+    /// #
+    /// # let running = StoppedJail::new("/rescue")
+    /// #     .name("testjail_racct")
+    /// #     .start()
+    /// #     .expect("Could not start jail");
+    /// match running.racct_statistics() {
+    ///     Ok(stats) => println!("{:#?}", stats),
+    ///     Err(e) => println!("Error: {}", e),
+    /// };
+    /// #
+    /// # running.kill();
+    /// ```
+    pub fn racct_statistics(&self) -> Result<HashMap<rctl::Resource, usize>, JailError> {
+        // First let's try to get the RACCT statistics in the happy path
+        rctl::Subject::jail_name(self.name()?)
+            .usage()
+            .map_err(JailError::RctlError)
     }
 }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,0 +1,34 @@
+use rctl;
+use stopped::StoppedJail;
+use nix::sys::signal::Signal;
+use std::process::Command;
+use process::Jailed;
+use std::os::unix::process::ExitStatusExt;
+
+#[test]
+fn test_rctl_yes() {
+    if !rctl::State::check().is_enabled() {
+        // If we don't have RCTL, let's just skip this test.
+        return;
+    }
+
+    let running = StoppedJail::new("/")
+        .name("testjail_rctl_yes")
+        .limit(rctl::Resource::Wallclock, rctl::Limit::amount(1), rctl::Action::Signal(Signal::SIGKILL))
+        .start()
+        .expect("Could not start Jail");
+
+    // this should hang until killed by the limit
+    let output = Command::new("/usr/bin/yes")
+        .jail(&running)
+        .output()
+        .expect("Failed to start yes command");
+
+    assert!(output.status.code() == None);
+    assert!(output.status.signal() == Some(9));
+
+    println!("{:?}", output);
+
+    running.stop()
+        .expect("Could not stop Jail");
+}


### PR DESCRIPTION
Closes #8 

- Implement wrappers for RCTL structures (moved to [fubarnetes/rctl](https://github.com/fubarnetes/rctl)):
  - [X] Subject
    - [X] `impl Display`
    - [X] Parser
    - [X] Docs
  - [X] Action
    - [X] `impl Display`
    - [X] Parser
    - [X] Docs
  - [X] Resource
    - [X] `impl Display`
    - [X] Parser
    - [X] Docs
  - [X] Limit
    - [x] `impl Display`
    - [X] Parser
    - [x] Docs
  - [x] Rule
    - [x] `impl Display`
    - [x] Parser
    - [x] Docs
  - [x] Filter
    - [x] `impl Display`
    - [x] Docs
- wrap functions (moved to [fubarnetes/rctl](https://github.com/fubarnetes/rctl)):
  - [x] Check kernel `RCTL`/`RACCT` support
  - [X] Iteration over all rules matching a `Filter`
  - [X] Iteration over all rules applying to a `Subject`
  - [X] add a rule
  - [X] remove all rules matching a `Filter`
  - [x] get accounting information for a subject
- Jail Boilerplate:
  - [X] Convenient wrapper to set rules on a `StoppedJail`, so that they get applied on jail start.
  - [X] Convenient wrapper to get resource usage information