### PR TITLE
Bump rctl to v0.0.4

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,14 @@
+task:
+  freebsd_instance:
+    matrix:
+      image: freebsd-12-0-release-amd64
+      image: freebsd-11-2-release-amd64
+  install_script: |
+    pkg install -y curl
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+    . $HOME/.cargo/env
+  cargo_cache:
+    folder: $CARGO_HOME/registry
+  build_script: env PATH="$HOME/.cargo/bin:$PATH" cargo build
+  test_script: env PATH="$HOME/.cargo/bin:$PATH" cargo test
+  before_cache_script: rm -rf $CARGO_HOME/registry/index

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ failure = "~0.1.1"
 libc = "~0.2.41"
 sysctl = "~0.2.0"
 nix= "^0.12.0"
-rctl = "0.0.3"
+rctl = "0.0.4"
 
 [dev-dependencies]
 prettytable-rs = "0.8.0"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,3 @@
-use nix::sys::signal::Signal;
 use process::Jailed;
 use rctl;
 use std::os::unix::process::ExitStatusExt;
@@ -17,7 +16,7 @@ fn test_rctl_yes() {
         .limit(
             rctl::Resource::Wallclock,
             rctl::Limit::amount(1),
-            rctl::Action::Signal(Signal::SIGKILL),
+            rctl::Action::Signal(rctl::Signal::SIGKILL),
         ).start()
         .expect("Could not start Jail");
 


### PR DESCRIPTION
Fixes the following build bug:

```
# cargo test   Compiling jail v0.0.5 (/root/libjail-rs)
error[E0308]: mismatched types  --> src/tests.rs:20:34   |20 |             rctl::Action::Signal(Signal::SIGKILL),   |                                  ^^^^^^^^^^^^^^^ expected enum `nix::sys::signal::Signal`, found a differ`   |   = note: expected type `nix::sys::signal::Signal` (enum `nix::sys::signal::Signal`)
              found type `nix::sys::signal::Signal` (enum `nix::sys::signal::Signal`)
note: Perhaps two different versions of crate `nix` are being used?
  --> src/tests.rs:20:34
   |
20 |             rctl::Action::Signal(Signal::SIGKILL),
   |                                  ^^^^^^^^^^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0308`.
error: Could not compile `jail`.
```