### PR TITLE
vnet: special-case vnet="inherit" when in save

### DIFF
--- a/src/running.rs
+++ b/src/running.rs
@@ -317,6 +317,12 @@ impl RunningJail {
             }
         }
 
+        // Special-Case VNET. Non-VNET jails have the "vnet" parameter set to
+        // "inherit" (2).
+        if stopped.params.get("vnet") == Some(&param::Value::Int(2)) {
+            stopped.params.remove("vnet");
+        }
+
         Ok(stopped)
     }
 


### PR DESCRIPTION
Non-VNET jails have `vnet="inherit"` set on them by the kernel. When
recreating these e.g. using `RunningJail::restart()`, this creates
problems, especially when IP address restrictions are set.

For now, we drop `vnet="inherit"` params when saving, so that non-VNET
jails stay non-VNET when restarted.