### PR TITLE
iteration: Publish RunningJails as RunningJailIter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+* Published `RunningJails` as `RunningJailIter`
+
 ## [0.0.6] - 2018-12-25
 
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub use error::JailError;
 
 mod running;
 pub use running::RunningJail;
+pub use running::RunningJails as RunningJailIter;
 
 mod stopped;
 pub use stopped::StoppedJail;


### PR DESCRIPTION
This type leaked out through `RunningJail::all()`, so we might as well
publish it.

This also helps with creating bindings that wrap the iterator.