### PR TITLE
RunningJail::from_jid: Check whether jail exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 ### Changed
 
 * Published `RunningJails` as `RunningJailIter`
+* `RunningJail::from_jid(...)` now returns an `Option<RunningJail>` depending on
+  whether a Jail exists with that JID. The old behaviour of
+  `RunningJail::from_jid(...)` can be found in
+  `RunningJail::from_jid_unchecked(...)`
 
 ### Bugfixes
 * `RunningJails::params()` now correctly fails when an error occurs while

--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -130,7 +130,7 @@ impl StoppedJail {
             );
         }
 
-        let ret = sys::jail_create(&path, params).map(RunningJail::from_jid)?;
+        let ret = sys::jail_create(&path, params).map(RunningJail::from_jid_unchecked)?;
 
         // Set resource limits
         if !self.limits.is_empty() {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -117,6 +117,27 @@ pub fn jail_create(
     }
 }
 
+/// Test if a jail exists. Returns
+pub fn jail_exists(jid: i32) -> bool {
+    let mut errmsg: [u8; 256] = unsafe { mem::zeroed() };
+    let mut jiov: Vec<libc::iovec> = vec![
+        iovec!(b"jid\0"),
+        iovec!(&jid as *const _, mem::size_of::<i32>()),
+        iovec!(b"errmsg\0"),
+        iovec!(errmsg.as_mut_ptr(), errmsg.len()),
+    ];
+
+    let retjid = unsafe {
+        libc::jail_get(
+            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov.len() as u32,
+            JailFlags::empty().bits,
+        )
+    };
+
+    jid == retjid
+}
+
 /// Clear the persist flag
 #[cfg(target_os = "freebsd")]
 pub fn jail_clearpersist(jid: i32) -> Result<(), JailError> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -39,7 +39,7 @@ fn test_rctl_yes() {
 #[test]
 fn test_name_nonexistent_jail() {
     // Assume Jail 424242 is not running
-    let r: RunningJail = RunningJail::from_jid(424242);
+    let r: RunningJail = RunningJail::from_jid_unchecked(424242);
 
     r.name()
         .expect_err("Could get name for jail 424242 which should not be running.");
@@ -48,7 +48,7 @@ fn test_name_nonexistent_jail() {
 #[test]
 fn test_params_nonexistent_jail() {
     // Assume Jail 424242 is not running
-    let r: RunningJail = RunningJail::from_jid(424242);
+    let r: RunningJail = RunningJail::from_jid_unchecked(424242);
 
     r.params()
         .expect_err("Could get name for jail 424242 which should not be running.");


### PR DESCRIPTION
`RunningJail::from_jid(...)` now returns an `Option<RunningJail>`
depending on whether a Jail exists with that JID. The old behaviour of
`RunningJail::from_jid(...)` can be found in
`RunningJail::from_jid_unchecked(...)`