### PR TITLE
Enable serializing stopped jails

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,8 +12,8 @@ task:
     . $HOME/.cargo/env
   cargo_cache:
     folder: $HOME/.cargo/registry
-  build_script: env PATH="$HOME/.cargo/bin:$PATH" cargo build
-  test_script: env PATH="$HOME/.cargo/bin:$PATH" cargo test
+  build_script: env PATH="$HOME/.cargo/bin:$PATH" cargo build --all-features
+  test_script: env PATH="$HOME/.cargo/bin:$PATH" cargo test --all-features
   coverage_script: |
     cat $0
     echo $SHELL

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ install:
 matrix:
   include:
   - env: TARGET=x86_64-unknown-freebsd
-    script: cargo build --target=$TARGET
+    script: cargo build --target=$TARGET --all-features
   - env: TARGET=i686-unknown-freebsd
-    script: cargo build --target=$TARGET
+    script: cargo build --target=$TARGET --all-features
     addons:
       apt:
         packages:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ travis-ci = { repository = "fubarnetes/libjail-rs", branch = "master" }
 is-it-maintained-issue-resolution = { repository = "fubarnetes/libjail-rs" }
 is-it-maintained-open-issues = { repository = "fubarnetes/libjail-rs" }
 
+[features]
+serialize = ["serde", "serde_json", "rctl/serialize"]
+
 [dependencies]
 bitflags = "^1"
 byteorder = "^1.2.3"
@@ -31,6 +34,8 @@ nix= "^0.13.0"
 rctl = "0.1.0"
 strum = "0.15.0"
 strum_macros = "0.15.0"
+serde = { version="1.0", features = ["derive"], optional=true}
+serde_json = { version="1.0", optional=true }
 
 [dev-dependencies]
 pretty_env_logger = "0.3"

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,0 +1,56 @@
+extern crate jail;
+
+#[macro_use]
+extern crate log;
+
+extern crate pretty_env_logger;
+extern crate rctl;
+#[cfg(features="serialize")]
+extern crate serde_json;
+
+use jail::param;
+use std::str::FromStr;
+
+#[cfg(feature="serialize")]
+fn main() {
+    pretty_env_logger::init();
+
+    let mut stopped = jail::StoppedJail::new("/rescue")
+        .name("example_serializing")
+        .ip("127.0.1.1".parse().expect("couldn't parse IP Addr"))
+        .ip("fe80::2".parse().expect("couldn't parse IP Addr"))
+        .param(
+            "osrelease",
+            param::Value::String("FreeBSD 42.23".to_string()),
+        )
+        .param("allow.raw_sockets", param::Value::Int(1))
+        .param("allow.sysvipc", param::Value::Int(1));
+
+    if rctl::State::check().is_enabled() {
+        // skip setting limits when racct is not enabled
+        stopped = stopped.limit(
+            rctl::Resource::from_str("maxproc")
+            .expect("couldn't parse Resource name"),
+            rctl::Limit::from_str("1000")
+            .expect("couldn't parse resource Limit"),
+            rctl::Action::Signal(rctl::Signal::SIGTERM));
+    }
+
+    stopped.hostname = Some("testjail.example.org".to_string());
+
+    let running = stopped.start().expect("Failed to start jail");
+
+    info!("created new jail with JID {}", running.jid);
+
+    let stopped = running.stop().expect("Failed to stop jail");
+
+    let serialized = serde_json::to_string_pretty(&stopped)
+        .expect("Failed to serialize jail");
+
+    println!("{}", serialized);
+}
+
+#[cfg(not(feature="serialize"))]
+fn main() {
+    println!("Run `cargo build --features=serialize` to enable this example.");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,12 @@ extern crate strum;
 #[macro_use]
 extern crate strum_macros;
 
+#[cfg(feature="serialize")]
+extern crate serde;
+
+#[cfg(feature="serialize")]
+extern crate serde_json;
+
 use std::collections::HashMap;
 use std::convert;
 use std::net;

--- a/src/param.rs
+++ b/src/param.rs
@@ -15,6 +15,8 @@ use JailError;
 
 use byteorder::{ByteOrder, LittleEndian, NetworkEndian, WriteBytesExt};
 use sysctl::{Ctl, CtlFlags, CtlType, CtlValue};
+#[cfg(feature="serialize")]
+use serde::{Serialize};
 
 use nix;
 
@@ -206,6 +208,7 @@ impl convert::Into<CtlType> for Type {
 /// An enum representing the value of a parameter.
 #[derive(EnumDiscriminants, Clone, PartialEq, Eq, Debug, Hash)]
 #[strum_discriminants(name(Type), derive(PartialOrd, Ord, Hash))]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub enum Value {
     Int(libc::c_int),
     String(String),

--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -8,11 +8,15 @@ use sys;
 use JailError;
 use RunningJail;
 
+#[cfg(feature="serialize")]
+use serde::{Serialize};
+
 use std::fmt;
 
 /// Represent a stopped jail including all information required to start it
 #[derive(Clone, PartialEq, Eq, Debug)]
 #[cfg(target_os = "freebsd")]
+#[cfg_attr(feature="serialize", derive(Serialize))]
 pub struct StoppedJail {
     /// The path of root file system of the jail
     pub path: Option<path::PathBuf>,
@@ -270,4 +274,5 @@ impl StoppedJail {
         self.ips.push(ip);
         self
     }
+
 }


### PR DESCRIPTION
This addresses #2 and enables serializing a stopped jail.

Requires [serialization support in fubarnetes/rctl](https://github.com/fubarnetes/rctl/pull/6)

Serialization is ~This could also be made~ optional via feature-flags.