### PR TITLE
bugfix: increase the type length limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 * Added debug logging using the `log` crate.
 
 ### Bugfixes
+* Increased `type_length_limit` to 17825821 to fix a build failure on
+  Rust 1.35.0 (See #59, #60, https://github.com/rust-lang/rust/issues/58952).
 * `RunningJails::params()` now correctly fails when an error occurs while
   reading parameters.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! it aims to provide the features exposed by the FreeBSD Jail Library
 //! [jail(3)](https://www.freebsd.org/cgi/man.cgi?query=jail&sektion=3&manpath=FreeBSD+11.1-stable)
 
+#![type_length_limit="17825821"]
+
 extern crate byteorder;
 
 #[macro_use]


### PR DESCRIPTION
Fixes a build failure on rust >= 1.35.0.

See also https://github.com/rust-lang/rust/issues/58952
Fixes #59