### PR TITLE
Use pre_exec instead of deprecated before_exec

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -45,13 +45,15 @@ impl Jailed for process::Command {
     fn jail(&mut self, jail: &RunningJail) -> &mut process::Command {
         trace!("process::Command::jail({:?}, jail={:?})", self, jail);
         let jail = *jail;
-        self.before_exec(move || {
-            trace!("before_exec handler: attaching");
-            jail.attach().map_err(|err| match err {
-                JailError::JailAttachError(e) => e,
-                _ => panic!("jail.attach() failed with unexpected error"),
-            })
-        });
+        unsafe {
+            self.pre_exec(move || {
+                trace!("pre_exec handler: attaching");
+                jail.attach().map_err(|err| match err {
+                    JailError::JailAttachError(e) => e,
+                    _ => panic!("jail.attach() failed with unexpected error"),
+                })
+            });
+        }
 
         self
     }


### PR DESCRIPTION
The std::os::unix::process::CommandExt implementation of before_exec is
falsely not marked `safe`, as it is executed in the fork, in a very
constrained environment.
Instead use the unsafe `pre_exec` method, which calls
`RunningJail::attach`. In the happy path, `attach` does not allocate,
and in the error path, it panics, so safety guarantees should be met.