### PR TITLE
Reduce type lengths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 **/*.rs.bk
 
 Cargo.lock
+
+# vim files
+*~
+*.swp

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 //! it aims to provide the features exposed by the FreeBSD Jail Library
 //! [jail(3)](https://www.freebsd.org/cgi/man.cgi?query=jail&sektion=3&manpath=FreeBSD+11.1-stable)
 
-#![type_length_limit = "314507289"]
-
 extern crate byteorder;
 
 #[macro_use]


### PR DESCRIPTION
This PR reduces the type lengths enough to make the `#![type_length_limit]` setting unnecessary.

We do this by avoiding a long filter chain and instead simply check for filtered names existing in a vec.

We also add some `vim` files to the `.gitignore`.