### PR TITLE
[vnet] Do not pass empty ip4.addr & ip6.addr params

### DIFF
--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -108,34 +108,38 @@ impl StoppedJail {
 
         let mut params = self.params.clone();
 
-        // Set the IP Addresses
-        params.insert(
-            "ip4.addr".into(),
-            param::Value::Ipv4Addrs(
-                self.ips
-                    .iter()
-                    .filter(|ip| ip.is_ipv4())
-                    .map(|ip| match ip {
-                        net::IpAddr::V4(ip4) => *ip4,
-                        _ => panic!("unreachable"),
-                    })
-                    .collect(),
-            ),
-        );
+        let ipv4_addresses: Vec<_> = self.ips
+            .iter()
+            .filter(|ip| ip.is_ipv4())
+            .map(|ip| match ip {
+                net::IpAddr::V4(ip4) => *ip4,
+                _ => unreachable!(),
+            })
+            .collect();
 
-        params.insert(
-            "ip6.addr".into(),
-            param::Value::Ipv6Addrs(
-                self.ips
-                    .iter()
-                    .filter(|ip| ip.is_ipv6())
-                    .map(|ip| match ip {
-                        net::IpAddr::V6(ip6) => *ip6,
-                        _ => panic!("unreachable"),
-                    })
-                    .collect(),
-            ),
-        );
+        if !ipv4_addresses.is_empty() {
+            // Set the IP Addresses
+            params.insert(
+                "ip4.addr".into(),
+                param::Value::Ipv4Addrs(ipv4_addresses),
+            );
+        }
+
+        let ipv6_addresses: Vec<_> = self.ips
+            .iter()
+            .filter(|ip| ip.is_ipv6())
+            .map(|ip| match ip {
+                net::IpAddr::V6(ip6) => *ip6,
+                _ => unreachable!(),
+            })
+            .collect();
+
+        if !ipv6_addresses.is_empty() {
+            params.insert(
+                "ip6.addr".into(),
+                param::Value::Ipv6Addrs(ipv6_addresses),
+            );
+        }
 
         if let Some(ref name) = self.name {
             params.insert("name".into(), param::Value::String(name.clone()));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -100,3 +100,14 @@ fn test_params_nonexistent_jail() {
     r.params()
         .expect_err("Could get name for jail 424242 which should not be running.");
 }
+
+#[test]
+fn test_vnet_jail() {
+    let running = StoppedJail::new("/")
+        .name("vnet_jail")
+        .param("vnet", param::Value::Int(1))
+        .start()
+        .expect("Could not start Jail");
+
+    running.stop().expect("Could not stop Jail");
+}


### PR DESCRIPTION
For vnet jails, passing either `ip4.addr` or `ip6.addr` params whether
empty or not results in following error: `vnet jails cannot have IP
address restrictions`.

This change works the aforementioned problem around by checking whether
the corresponding vectors are empty and if they are, not passing the
parameters at all.