### PR TITLE
Fix Cirrus CI builds

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,8 +1,8 @@
 task:
   freebsd_instance:
     matrix:
-      image: freebsd-12-0-release-amd64
-      image: freebsd-11-2-release-amd64
+      image: freebsd-12-1-release-amd64
+      image: freebsd-11-4-release-amd64
   env:
     CIRRUS_SHELL: /bin/sh
     CODECOV_TOKEN: ENCRYPTED[4a184dabcd401205e29abdf52d0b4dde9d5029ac26ced03035962839b5f70a157cece9ff4f12812db5a72c06263a85fb]
@@ -18,9 +18,9 @@ task:
     cat $0
     echo $SHELL
     ls -lha target
-    find target/debug -maxdepth 1 -iname 'jail-*[^\.d]'
+    find target/debug/deps -maxdepth 1 -iname 'jail-*[^\.d]'
     pkg install -y kcov bash git
-    for file in target/debug/jail-*[^\.d]; do
+    for file in target/debug/deps/jail-*[^\.d]; do
       mkdir -p "target/cov/`basename $file`"
       kcov --exclude-pattern=$HOME/.cargo,/usr/lib,/usr/local/lib,/usr/src/lib/ --verify "target/cov/`basename $file`" "$file"
     done

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -103,6 +103,23 @@ fn test_params_nonexistent_jail() {
 
 #[test]
 fn test_vnet_jail() {
+    use sysctl::{Ctl, Sysctl, CtlValue::String};
+
+    let ctl = Ctl::new("kern.osrelease")
+        .expect("Failed to read kern.osrelease sysctl")
+        .value()
+        .expect("Failed to parse kern.osrelease sysctl");
+
+    let version = match ctl {
+        String(value) => value[0..2].parse::<u32>(),
+        _ => Ok(0),
+    }.unwrap_or(0);
+
+    if version < 12 {
+        // Earlier versions do not support vnet flag, skipping.
+        return;
+    }
+
     let running = StoppedJail::new("/")
         .name("vnet_jail")
         .param("vnet", param::Value::Int(1))


### PR DESCRIPTION
Currently listed GCP images fail to install software using pkg. The
message is `pkg: repository meta /var/db/pkg/FreeBSD.meta has wrong
version 2`.

This change
* attempts to fix the aforementioned error by using other,
  Cirrus-documented [images](https://cirrus-ci.org/guide/FreeBSD/).
* Since kernel supports the vnet jails flag since version 12, skips the vnet test
  depending on the kernel version