### PR TITLE
Update crate edition to 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["freebsd", "jail", "container", "chroot"]
 categories = ["os::unix-apis", "api-bindings"]
 readme = "README.md"
 exclude = [ ".cirrus.yml", ".github", ".gitignore", ".travis.yml", "ci" ]
+edition = "2018"
 
 [lib]
 name = "jail"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
-use param;
+use crate::param;
+use failure::Fail;
 use rctl;
 use sysctl;
-
 use std::io;
 
 /// An enum for error types of the Jail.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use crate::param;
 use failure::Fail;
 use rctl;
-use sysctl;
 use std::io;
+use sysctl;
 
 /// An enum for error types of the Jail.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,43 +3,14 @@
 //! it aims to provide the features exposed by the FreeBSD Jail Library
 //! [jail(3)](https://www.freebsd.org/cgi/man.cgi?query=jail&sektion=3&manpath=FreeBSD+11.1-stable)
 
-extern crate byteorder;
-
-#[macro_use]
-extern crate failure;
-
-extern crate libc;
-
-#[macro_use]
-extern crate log;
-
-extern crate sysctl;
-
-#[macro_use]
-mod sys;
-
-#[macro_use]
-extern crate bitflags;
-
-extern crate nix;
-
-extern crate rctl;
-
-extern crate strum;
-
-#[macro_use]
-extern crate strum_macros;
-
-#[cfg(feature = "serialize")]
-extern crate serde;
-
-#[cfg(feature = "serialize")]
-extern crate serde_json;
-
+use log::trace;
 use std::collections::HashMap;
 use std::convert;
 use std::net;
 use std::path;
+
+#[macro_use]
+mod sys;
 
 mod error;
 pub use error::JailError;

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,7 +1,10 @@
 //! Module for inspection and manipulation of jail parameters
-
+use crate::JailError;
+use crate::sys::JailFlags;
+use byteorder::{ByteOrder, LittleEndian, NetworkEndian, WriteBytesExt};
 use libc;
-
+use log::trace;
+use nix;
 use std::collections::HashMap;
 use std::convert;
 use std::ffi::{CStr, CString};
@@ -9,16 +12,11 @@ use std::iter::FromIterator;
 use std::mem;
 use std::net;
 use std::slice;
-
-use sys::JailFlags;
-use JailError;
-
-use byteorder::{ByteOrder, LittleEndian, NetworkEndian, WriteBytesExt};
-#[cfg(feature = "serialize")]
-use serde::Serialize;
+use strum_macros::EnumDiscriminants;
 use sysctl::{Ctl, CtlFlags, CtlType, CtlValue, Sysctl};
 
-use nix;
+#[cfg(feature = "serialize")]
+use serde::Serialize;
 
 #[cfg(target_os = "freebsd")]
 impl Type {

--- a/src/param.rs
+++ b/src/param.rs
@@ -1,6 +1,6 @@
 //! Module for inspection and manipulation of jail parameters
-use crate::JailError;
 use crate::sys::JailFlags;
+use crate::JailError;
 use byteorder::{ByteOrder, LittleEndian, NetworkEndian, WriteBytesExt};
 use libc;
 use log::trace;

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,11 +1,8 @@
 //! Jail-Specific extensions to the `std::process` module
-
-use std::process;
-
+use crate::{JailError, RunningJail};
+use log::trace;
 use std::os::unix::process::CommandExt;
-
-use JailError;
-use RunningJail;
+use std::process;
 
 /// Extension to the `std::process::Command` builder to run the command in a
 /// jail.

--- a/src/running.rs
+++ b/src/running.rs
@@ -1,10 +1,7 @@
+use crate::{param, sys, JailError, StoppedJail};
 use libc;
-use param;
+use log::trace;
 use rctl;
-use sys;
-use JailError;
-use StoppedJail;
-
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::{Error, ErrorKind};

--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -1,18 +1,14 @@
+use crate::{param, sys, JailError, RunningJail};
+use log::trace;
+use rctl;
 use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fmt;
 use std::net;
 use std::path;
 
-use param;
-use rctl;
-use sys;
-use JailError;
-use RunningJail;
-
 #[cfg(feature = "serialize")]
 use serde::Serialize;
-
-use std::convert::TryFrom;
-use std::fmt;
 
 /// Represent a stopped jail including all information required to start it
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -104,7 +104,8 @@ impl StoppedJail {
 
         let mut params = self.params.clone();
 
-        let ipv4_addresses: Vec<_> = self.ips
+        let ipv4_addresses: Vec<_> = self
+            .ips
             .iter()
             .filter(|ip| ip.is_ipv4())
             .map(|ip| match ip {
@@ -115,13 +116,12 @@ impl StoppedJail {
 
         if !ipv4_addresses.is_empty() {
             // Set the IP Addresses
-            params.insert(
-                "ip4.addr".into(),
-                param::Value::Ipv4Addrs(ipv4_addresses),
-            );
+            let value = param::Value::Ipv4Addrs(ipv4_addresses);
+            params.insert("ip4.addr".into(), value);
         }
 
-        let ipv6_addresses: Vec<_> = self.ips
+        let ipv6_addresses: Vec<_> = self
+            .ips
             .iter()
             .filter(|ip| ip.is_ipv6())
             .map(|ip| match ip {
@@ -131,10 +131,8 @@ impl StoppedJail {
             .collect();
 
         if !ipv6_addresses.is_empty() {
-            params.insert(
-                "ip6.addr".into(),
-                param::Value::Ipv6Addrs(ipv6_addresses),
-            );
+            let value = param::Value::Ipv6Addrs(ipv6_addresses);
+            params.insert("ip6.addr".into(), value);
         }
 
         if let Some(ref name) = self.name {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,15 +1,13 @@
+use crate::{param, JailError};
+use bitflags::bitflags;
 use libc;
-
+use log::trace;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::mem;
+use std::path;
 use std::ptr;
 use std::str;
-
-use std::path;
-
-use param;
-use JailError;
 
 macro_rules! iovec {
     ($key:expr => ($value:expr, $size:expr)) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -101,7 +101,7 @@ fn test_params_nonexistent_jail() {
 
 #[test]
 fn test_vnet_jail() {
-    use sysctl::{Ctl, Sysctl, CtlValue::String};
+    use sysctl::{Ctl, CtlValue::String, Sysctl};
 
     let ctl = Ctl::new("kern.osrelease")
         .expect("Failed to read kern.osrelease sysctl")

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,12 +1,10 @@
-use param;
-use process::Jailed;
+use crate::param;
+use crate::process::Jailed;
+use crate::running::RunningJail;
+use crate::stopped::StoppedJail;
 use rctl;
-use running::RunningJail;
-#[cfg(feature = "serialize")]
-use serde_json;
 use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
-use stopped::StoppedJail;
 
 #[cfg(feature = "serialize")]
 #[test]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -111,7 +111,8 @@ fn test_vnet_jail() {
     let version = match ctl {
         String(value) => value[0..2].parse::<u32>(),
         _ => Ok(0),
-    }.unwrap_or(0);
+    }
+    .unwrap_or(0);
 
     if version < 12 {
         // Earlier versions do not support vnet flag, skipping.


### PR DESCRIPTION
This PR updates the crate edition to 2018.

A lot of `extern crate` gets removed due to this, and more specific `use` statements were added where required. `use` statements also got alphabetised, with the exception of our own `crate` imports being at the top of the lists.

Tests should be fine, but I haven't ran them as `root` so I didn't get to see the output from all of them. I look forward to the CI run for the PR :) 