### PR TITLE
Fix clippy lints and style issues

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,5 @@
 use crate::param;
-use rctl;
 use std::io;
-use sysctl;
 use thiserror::Error;
 
 /// An enum for error types of the Jail.

--- a/src/param.rs
+++ b/src/param.rs
@@ -257,7 +257,7 @@ impl Value {
         let mut bytes: Vec<u8> = vec![];
 
         // Some conversions are identity on 64 bit, but not on 32 bit and vice versa
-        #[cfg_attr(feature = "cargo-clippy", allow(identity_conversion))]
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
         match self {
             Value::String(s) => {
                 bytes = CString::new(s.as_str())
@@ -277,12 +277,14 @@ impl Value {
             Value::Int(v) => {
                 bytes.write_int::<LittleEndian>((*v).into(), mem::size_of::<libc::c_int>())
             }
-            Value::Long(v) => bytes.write_int::<LittleEndian>(*v, mem::size_of::<libc::c_long>()),
+            Value::Long(v) => {
+                bytes.write_int::<LittleEndian>((*v).into(), mem::size_of::<libc::c_long>())
+            }
             Value::Uint(v) => {
                 bytes.write_uint::<LittleEndian>((*v).into(), mem::size_of::<libc::c_uint>())
             }
             Value::Ulong(v) => {
-                bytes.write_uint::<LittleEndian>(*v, mem::size_of::<libc::c_ulong>())
+                bytes.write_uint::<LittleEndian>((*v).into(), mem::size_of::<libc::c_ulong>())
             }
             Value::Ipv4Addrs(addrs) => {
                 for addr in addrs {
@@ -419,14 +421,15 @@ impl Value {
     /// ```
     pub fn unpack_u64(self) -> Result<u64, JailError> {
         trace!("Value::unpack_u64({:?})", self);
-        #[cfg_attr(feature = "cargo-clippy", allow(identity_conversion))]
+        // Some conversions are identity on 64 bit, but not on 32 bit and vice versa
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
         match self {
             Value::U64(v) => Ok(v),
             Value::U32(v) => Ok(v.into()),
             Value::U16(v) => Ok(v.into()),
             Value::U8(v) => Ok(v.into()),
             Value::Uint(v) => Ok(v.into()),
-            Value::Ulong(v) => Ok(v),
+            Value::Ulong(v) => Ok(v.into()),
             _ => Err(JailError::ParameterUnpackError),
         }
     }
@@ -456,7 +459,8 @@ impl Value {
     /// ```
     pub fn unpack_i64(self) -> Result<i64, JailError> {
         trace!("Value::unpack_i64({:?})", self);
-        #[cfg_attr(feature = "cargo-clippy", allow(identity_conversion))]
+        // Some conversions are identity on 64 bit, but not on 32 bit and vice versa
+        #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
         match self {
             Value::S64(v) => Ok(v),
             Value::S32(v) => Ok(v.into()),
@@ -467,7 +471,7 @@ impl Value {
             Value::U8(v) => Ok(v.into()),
             Value::Uint(v) => Ok(v.into()),
             Value::Int(v) => Ok(v.into()),
-            Value::Long(v) => Ok(v),
+            Value::Long(v) => Ok(v.into()),
             _ => Err(JailError::ParameterUnpackError),
         }
     }

--- a/src/param.rs
+++ b/src/param.rs
@@ -61,9 +61,18 @@ impl Type {
         trace!("Type::is_numeric({:?})", self);
         matches!(
             self,
-            Type::S8  | Type::S16  | Type::S32  | Type::S64 |
-            Type::U8  | Type::U16  | Type::U32  | Type::U64 |
-            Type::Int | Type::Long | Type::Uint | Type::Ulong
+            Type::S8
+                | Type::S16
+                | Type::S32
+                | Type::S64
+                | Type::U8
+                | Type::U16
+                | Type::U32
+                | Type::U64
+                | Type::Int
+                | Type::Long
+                | Type::Uint
+                | Type::Ulong
         )
     }
 
@@ -82,8 +91,7 @@ impl Type {
         trace!("Type::is_signed({:?})", self);
         matches!(
             self,
-            Type::S8  | Type::S16 | Type::S32 | Type::S64 |
-            Type::Int | Type::Long
+            Type::S8 | Type::S16 | Type::S32 | Type::S64 | Type::Int | Type::Long
         )
     }
 
@@ -269,9 +277,7 @@ impl Value {
             Value::Int(v) => {
                 bytes.write_int::<LittleEndian>((*v).into(), mem::size_of::<libc::c_int>())
             }
-            Value::Long(v) => {
-                bytes.write_int::<LittleEndian>(*v, mem::size_of::<libc::c_long>())
-            }
+            Value::Long(v) => bytes.write_int::<LittleEndian>(*v, mem::size_of::<libc::c_long>()),
             Value::Uint(v) => {
                 bytes.write_uint::<LittleEndian>((*v).into(), mem::size_of::<libc::c_uint>())
             }

--- a/src/running.rs
+++ b/src/running.rs
@@ -1,7 +1,5 @@
 use crate::{param, sys, JailError, StoppedJail};
-use libc;
 use log::trace;
-use rctl;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::{Error, ErrorKind};
@@ -119,7 +117,7 @@ impl RunningJail {
     /// #
     /// # running.kill();
     /// ```
-    pub fn name(self: &RunningJail) -> Result<String, JailError> {
+    pub fn name(&self) -> Result<String, JailError> {
         trace!("RunningJail::name({:?})", self);
         self.param("name")?.unpack_string()
     }
@@ -143,7 +141,7 @@ impl RunningJail {
     /// #
     /// # running.kill();
     /// ```
-    pub fn path(self: &RunningJail) -> Result<path::PathBuf, JailError> {
+    pub fn path(&self) -> Result<path::PathBuf, JailError> {
         trace!("RunningJail::path({:?})", self);
         Ok(self.param("path")?.unpack_string()?.into())
     }
@@ -167,7 +165,7 @@ impl RunningJail {
     /// #
     /// # running.kill();
     /// ```
-    pub fn hostname(self: &RunningJail) -> Result<String, JailError> {
+    pub fn hostname(&self) -> Result<String, JailError> {
         trace!("RunningJail::hostname({:?})", self);
         self.param("host.hostname")?.unpack_string()
     }
@@ -190,7 +188,7 @@ impl RunningJail {
     /// assert_eq!(ips[1], "fe80::2".parse::<IpAddr>().unwrap());
     /// # running.kill();
     /// ```
-    pub fn ips(self: &RunningJail) -> Result<Vec<net::IpAddr>, JailError> {
+    pub fn ips(&self) -> Result<Vec<net::IpAddr>, JailError> {
         trace!("RunningJail::ips({:?})", self);
         let mut ips: Vec<net::IpAddr> = vec![];
         ips.extend(
@@ -224,7 +222,7 @@ impl RunningJail {
     /// # println!("jail uuid: {:?}", hostuuid);
     /// # running.kill();
     /// ```
-    pub fn param(self: &Self, name: &str) -> Result<param::Value, JailError> {
+    pub fn param(&self, name: &str) -> Result<param::Value, JailError> {
         trace!("RunningJail::param({:?}, name={})", self, name);
         param::get(self.jid, name)
     }
@@ -250,7 +248,7 @@ impl RunningJail {
     /// );
     /// # running.kill().expect("could not stop jail");
     /// ```
-    pub fn params(self: &Self) -> Result<HashMap<String, param::Value>, JailError> {
+    pub fn params(&self) -> Result<HashMap<String, param::Value>, JailError> {
         trace!("RunningJail::params({:?})", self);
         param::get_all(self.jid)
     }
@@ -271,7 +269,7 @@ impl RunningJail {
     /// # assert_eq!(readback, param::Value::Int(1));
     /// # running.kill();
     /// ```
-    pub fn param_set(self: &Self, name: &str, value: param::Value) -> Result<(), JailError> {
+    pub fn param_set(&self, name: &str, value: param::Value) -> Result<(), JailError> {
         trace!(
             "RunningJail::param_set({:?}, name={:?}, value={:?})",
             self,
@@ -294,14 +292,14 @@ impl RunningJail {
     /// #     .start().unwrap();
     /// running.kill();
     /// ```
-    pub fn kill(self: RunningJail) -> Result<(), JailError> {
+    pub fn kill(self) -> Result<(), JailError> {
         trace!("RunningJail::kill({:?})", self);
         let name = self.name()?;
         sys::jail_remove(self.jid)?;
 
         // Tear down RCTL rules
         {
-            if &name == "" {
+            if name.is_empty() {
                 return Ok(());
             }
 

--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -219,11 +219,7 @@ impl StoppedJail {
     /// let mut stopped = StoppedJail::new("/rescue")
     ///     .param("allow.raw_sockets", param::Value::Int(1));
     /// ```
-    pub fn param<S: Into<String> + fmt::Debug>(
-        mut self,
-        param: S,
-        value: param::Value,
-    ) -> Self {
+    pub fn param<S: Into<String> + fmt::Debug>(mut self, param: S, value: param::Value) -> Self {
         trace!(
             "StoppedJail::param({:?}, param={:?}, value={:?})",
             self,

--- a/src/stopped.rs
+++ b/src/stopped.rs
@@ -1,6 +1,5 @@
 use crate::{param, sys, JailError, RunningJail};
 use log::trace;
-use rctl;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -70,9 +69,11 @@ impl StoppedJail {
     /// ```
     pub fn new<P: Into<path::PathBuf> + fmt::Debug>(path: P) -> StoppedJail {
         trace!("StoppedJail::new(path={:?})", path);
-        let mut ret: StoppedJail = Default::default();
-        ret.path = Some(path.into());
-        ret
+
+        StoppedJail {
+            path: Some(path.into()),
+            ..Default::default()
+        }
     }
 
     /// Start the jail
@@ -90,7 +91,7 @@ impl StoppedJail {
     /// let running = stopped.start().unwrap();
     /// # running.kill();
     /// ```
-    pub fn start(self: StoppedJail) -> Result<RunningJail, JailError> {
+    pub fn start(self) -> Result<RunningJail, JailError> {
         trace!("StoppedJail::start({:?})", self);
         let path = match self.path {
             None => return Err(JailError::PathNotGiven),
@@ -181,7 +182,7 @@ impl StoppedJail {
     ///
     /// assert_eq!(stopped.name, Some("test_stopped_name".to_string()));
     /// ```
-    pub fn name<S: Into<String> + fmt::Debug>(mut self: Self, name: S) -> Self {
+    pub fn name<S: Into<String> + fmt::Debug>(mut self, name: S) -> Self {
         trace!("StoppedJail::start({:?}, name={:?})", self, name);
         self.name = Some(name.into());
         self
@@ -200,7 +201,7 @@ impl StoppedJail {
     ///
     /// assert_eq!(stopped.hostname, Some("example.com".to_string()));
     /// ```
-    pub fn hostname<S: Into<String> + fmt::Debug>(mut self: Self, hostname: S) -> Self {
+    pub fn hostname<S: Into<String> + fmt::Debug>(mut self, hostname: S) -> Self {
         trace!("StoppedJail::hostname({:?}, hostname={:?})", self, hostname);
         self.hostname = Some(hostname.into());
         self
@@ -219,7 +220,7 @@ impl StoppedJail {
     ///     .param("allow.raw_sockets", param::Value::Int(1));
     /// ```
     pub fn param<S: Into<String> + fmt::Debug>(
-        mut self: Self,
+        mut self,
         param: S,
         value: param::Value,
     ) -> Self {
@@ -276,7 +277,7 @@ impl StoppedJail {
     ///     .ip("127.0.1.1".parse().expect("could not parse 127.0.1.1"))
     ///     .ip("fe80::2".parse().expect("could not parse ::1"));
     /// ```
-    pub fn ip(mut self: Self, ip: net::IpAddr) -> Self {
+    pub fn ip(mut self, ip: net::IpAddr) -> Self {
         trace!("StoppedJail::ip({:?}, ip={:?})", self, ip);
         self.ips.push(ip);
         self

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,6 +1,5 @@
 use crate::{param, JailError};
 use bitflags::bitflags;
-use libc;
 use log::trace;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};


### PR DESCRIPTION
This changes a few things to make clippy happy:
  - Removes redundant `use` statements
  - Changes some `match` statements to `matches!()` macros
  - Changes an `Into` `impl` to a `From` `impl`
  - Changes `Value::as_bytes()` to take `&self`
  - Removes various `.into()` calls where they're not needed
  - Specify allowed clippys by full `clippy::` path
  - Removes redundant `self` types from the `self` param on some `impl`
    methods
  - Fixes various style issues to pass CI
  - Renames the old `identity_conversion` clippy to `clippy::useless_conversion`
  - Probably something else I missed