### PR TITLE
Update examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,5 @@ serde_json = { version="1.0", optional=true }
 thiserror = "1.0"
 
 [dev-dependencies]
+cli-table = { version="0.4", default-features=false, features=["derive"] }
 pretty_env_logger = "0.4"
-prettytable-rs = "0.8.0"
-

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,15 +1,7 @@
-extern crate jail;
-
-#[macro_use]
-extern crate log;
-
-extern crate pretty_env_logger;
-extern crate rctl;
-
-use std::process::Command;
-
+use log::{error, info, warn};
 use jail::param;
 use jail::process::Jailed;
+use std::process::Command;
 
 fn main() {
     pretty_env_logger::init();

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,6 +1,6 @@
-use log::{error, info, warn};
 use jail::param;
 use jail::process::Jailed;
+use log::{error, info, warn};
 use std::process::Command;
 
 fn main() {

--- a/examples/jls.rs
+++ b/examples/jls.rs
@@ -1,18 +1,25 @@
-extern crate jail;
-
-extern crate pretty_env_logger;
-
-#[macro_use]
-extern crate prettytable;
-
+use cli_table::{print_stdout, Table, WithTitle};
 use jail::RunningJail;
-use prettytable::{Cell, Row, Table};
+
+#[derive(Table)]
+struct Jail {
+    #[table(title = "JID")]
+    jid: i32,
+
+    #[table(title = "IP Address")]
+    ips: String,
+
+    #[table(title = "Hostname")]
+    hostname: String,
+
+    #[table(title = "Path")]
+    path: String,
+}
 
 fn main() {
     pretty_env_logger::init();
 
-    let mut table = Table::new();
-    table.add_row(row!["JID", "IP Address", "Hostname", "Path"]);
+    let mut jails = Vec::new();
 
     for j in RunningJail::all() {
         let ips: Vec<String> = j
@@ -22,13 +29,15 @@ fn main() {
             .map(|ip| format!("{}", ip))
             .collect();
 
-        table.add_row(Row::new(vec![
-            Cell::new(&format!("{}", j.jid)),
-            Cell::new(&ips.join("\n")),
-            Cell::new(&format!("{}", j.hostname().unwrap())),
-            Cell::new(j.path().unwrap().to_str().unwrap()),
-        ]));
+        let jail = Jail {
+            jid: j.jid,
+            ips: ips.join("\n"),
+            hostname: j.hostname().unwrap(),
+            path: j.path().unwrap().to_str().unwrap().to_string(),
+        };
+
+        jails.push(jail);
     }
 
-    table.printstd();
+    print_stdout(jails.with_title()).unwrap();
 }

--- a/examples/non_persistent.rs
+++ b/examples/non_persistent.rs
@@ -1,4 +1,3 @@
-extern crate jail;
 use jail::process::Jailed;
 use std::process::Command;
 

--- a/examples/resource_accounting.rs
+++ b/examples/resource_accounting.rs
@@ -1,6 +1,6 @@
 use jail::process::Jailed;
-use std::{thread, time};
 use std::process::{Command, Stdio};
+use std::{thread, time};
 
 fn main() {
     if !rctl::State::check().is_enabled() {

--- a/examples/resource_accounting.rs
+++ b/examples/resource_accounting.rs
@@ -1,10 +1,6 @@
-extern crate jail;
-extern crate rctl;
-
-use std::process::{Command, Stdio};
-
 use jail::process::Jailed;
 use std::{thread, time};
+use std::process::{Command, Stdio};
 
 fn main() {
     if !rctl::State::check().is_enabled() {

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -1,14 +1,10 @@
-extern crate jail;
+#[cfg(feature = "serialize")]
+use log::info;
 
-#[macro_use]
-extern crate log;
-
-extern crate pretty_env_logger;
-extern crate rctl;
-#[cfg(features = "serialize")]
-extern crate serde_json;
-
+#[cfg(feature = "serialize")]
 use jail::param;
+
+#[cfg(feature = "serialize")]
 use std::str::FromStr;
 
 #[cfg(feature = "serialize")]


### PR DESCRIPTION
Closes: #97 
Closes: #99 

This updates the examples to Rust 2018 and replaces the `prettytable-rs` crate with `cli-table` for the jls example.

`cli-table` was chosen as it was the smaller of the two options listed in #99 as well as being dual licensed as MIT/Apache-2.0.