### PR TITLE
Update multiple dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,7 +21,7 @@ task:
         image: freebsd-14-1-release-amd64-ufs
     - name: FreeBSD 14 amd64 stable
       env:
-        VERSION: 1.66.0
+        VERSION: 1.80.0
       freebsd_instance:
         image: freebsd-14-1-release-amd64-ufs
     - name: FreeBSD 14 i686 nightly
@@ -30,7 +30,7 @@ task:
         TARGET: i686-unknown-freebsd
         # Can't use nightly on i686 due to
         # https://github.com/rust-lang/rust/issues/130677
-        VERSION: 1.66.0
+        VERSION: 1.80.0
       freebsd_instance:
         image: freebsd-14-1-release-amd64-ufs
   << : *SETUP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
+## Changed
+* Updated MSRV to 1.80.0 (#132)
+* Updated `nix`, `strum`, and `bitflags` dependencies (#132)
+
 ## [0.2.0] - 2021-09-25
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/jail"
 keywords = ["freebsd", "jail", "container", "chroot"]
 categories = ["os::unix-apis", "api-bindings"]
 readme = "README.md"
-rust-version = "1.66"
+rust-version = "1.80"
 exclude = [ ".cirrus.yml", ".github", ".gitignore", ".travis.yml", "ci" ]
 edition = "2018"
 
@@ -35,15 +35,14 @@ is-it-maintained-open-issues = { repository = "fubarnetes/libjail-rs" }
 serialize = ["serde", "serde_json", "rctl/serialize"]
 
 [dependencies]
-bitflags = "1.3.0"
+bitflags = "2.6.0"
 byteorder = "1.4.3"
-libc = "0.2.98"
+libc = "0.2.155"
 log="0.4.8"
 sysctl = "~0.5.4"
-nix= "^0.22.0"
+nix = { version = "0.29.0", default-features = false, features = ["socket"] }
 rctl = "0.2.0"
-strum = "0.21.0"
-strum_macros = "0.21.1"
+strum_macros = "0.26.0"
 serde = { version="1.0.113", features = ["derive"], optional=true}
 serde_json = { version="1.0", optional=true }
 thiserror = "1.0.32"

--- a/src/param.rs
+++ b/src/param.rs
@@ -288,8 +288,7 @@ impl Value {
             }
             Value::Ipv4Addrs(addrs) => {
                 for addr in addrs {
-                    let s_addr = nix::sys::socket::Ipv4Addr::from_std(addr).0.s_addr;
-                    let host_u32 = u32::from_be(s_addr);
+                    let host_u32 = addr.to_bits();
                     bytes
                         .write_u32::<NetworkEndian>(host_u32)
                         .map_err(|_| JailError::SerializeFailed)?;

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -39,7 +39,7 @@ macro_rules! iovec {
 }
 
 bitflags! {
-    pub struct JailFlags : i32 {
+    pub(crate) struct JailFlags : i32 {
         /// Create the Jail if it doesn't exist
         const CREATE = 0x01;
 
@@ -106,7 +106,7 @@ pub fn jail_create(
         libc::jail_set(
             jiov[..].as_mut_ptr(),
             jiov.len() as u32,
-            JailFlags::CREATE.bits,
+            JailFlags::CREATE.bits(),
         )
     };
 
@@ -139,7 +139,7 @@ pub fn jail_exists(jid: i32) -> bool {
         libc::jail_get(
             jiov[..].as_mut_ptr(),
             jiov.len() as u32,
-            JailFlags::empty().bits,
+            JailFlags::empty().bits(),
         )
     };
 
@@ -164,7 +164,7 @@ pub fn jail_clearpersist(jid: i32) -> Result<(), JailError> {
         libc::jail_set(
             jiov[..].as_mut_ptr(),
             jiov.len() as u32,
-            JailFlags::UPDATE.bits,
+            JailFlags::UPDATE.bits(),
         )
     };
 
@@ -206,7 +206,7 @@ pub fn jail_getid(name: &str) -> Result<i32, JailError> {
         libc::jail_get(
             jiov[..].as_mut_ptr(),
             jiov.len() as u32,
-            JailFlags::empty().bits,
+            JailFlags::empty().bits(),
         )
     };
 
@@ -241,7 +241,7 @@ pub fn jail_nextjid(lastjid: i32) -> Result<i32, JailError> {
         libc::jail_get(
             jiov[..].as_mut_ptr(),
             jiov.len() as u32,
-            JailFlags::empty().bits,
+            JailFlags::empty().bits(),
         )
     };
 


### PR DESCRIPTION
* Update bitflags dep to 2.6.0, to eliminate duplicate dependency
* Update strum dependency.  Removes duplicate dependencies on heck and syn.
* Update nix to 0.29.0.  Soon, the rctl dependency will be updated too, and it will use nix-0.29.