### PR TITLE
Expand the range of allowed versions of the sysctl crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ bitflags = "2.6.0"
 byteorder = "1.4.3"
 libc = "0.2.155"
 log="0.4.8"
-sysctl = "~0.5.4"
+sysctl = ">=0.5.4, < 0.7"
 nix = { version = "0.29.0", default-features = false, features = ["socket"] }
 rctl = "0.2.0"
 strum_macros = "0.26.0"


### PR DESCRIPTION
sysctl just release 0.6.0.  Even though it has no breaking changes, they gave it a new minor version.  Allow libjail-rs consumers to use either version 0.5 or 0.6.