### PR TITLE
Various CI changes, and raise cli_table to 0.5

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,18 +18,18 @@ task:
         image: freebsd-13-4-release-amd64
     - name: FreeBSD 14 amd64 nightly
       freebsd_instance:
-        image: freebsd-14-1-release-amd64-ufs
+        image: freebsd-14-2-release-amd64-ufs
     - name: FreeBSD 14 amd64 stable
       env:
         VERSION: 1.80.0
       freebsd_instance:
-        image: freebsd-14-1-release-amd64-ufs
+        image: freebsd-14-2-release-amd64-ufs
     - name: FreeBSD 14 i686 nightly
       # Test i686 FreeBSD in 32-bit emulation on a 64-bit host.
       env:
         TARGET: i686-unknown-freebsd
       freebsd_instance:
-        image: freebsd-14-1-release-amd64-ufs
+        image: freebsd-14-2-release-amd64-ufs
   << : *SETUP
   extra_setup_script:
     - . $HOME/.cargo/env
@@ -57,7 +57,7 @@ lint_task:
     HOME: /tmp  # cargo cache needs it
     VERSION: nightly
   freebsd_instance:
-    image: freebsd-14-1-release-amd64-ufs
+    image: freebsd-14-2-release-amd64-ufs
   << : *SETUP
   extra_setup_script:
     - . $HOME/.cargo/env

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,9 +28,6 @@ task:
       # Test i686 FreeBSD in 32-bit emulation on a 64-bit host.
       env:
         TARGET: i686-unknown-freebsd
-        # Can't use nightly on i686 due to
-        # https://github.com/rust-lang/rust/issues/130677
-        VERSION: 1.80.0
       freebsd_instance:
         image: freebsd-14-1-release-amd64-ufs
   << : *SETUP

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -6,12 +6,15 @@ setup: &SETUP
     - pkg install -y llvm
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $VERSION
+    - . $HOME/.cargo/env
+    - rustup toolchain install --profile=minimal $TEST_VERSION
 
 task:
   env:
     HOME: /tmp  # cargo cache needs it
     TARGET: x86_64-unknown-freebsd
     VERSION: nightly
+    TEST_VERSION: nightly
   matrix:
     - name: FreeBSD 13 amd64 nightly
       freebsd_instance:
@@ -22,6 +25,7 @@ task:
     - name: FreeBSD 14 amd64 stable
       env:
         VERSION: 1.80.0
+        TEST_VERSION: 1.85.0
       freebsd_instance:
         image: freebsd-14-2-release-amd64-ufs
     - name: FreeBSD 14 i686 nightly
@@ -34,16 +38,17 @@ task:
   extra_setup_script:
     - . $HOME/.cargo/env
     - if [ "$TARGET" = "i686-unknown-freebsd" ]; then rustup target add --toolchain $VERSION i686-unknown-freebsd; fi
+    - if [ "$TARGET" = "i686-unknown-freebsd" ]; then rustup target add --toolchain $TEST_VERSION i686-unknown-freebsd; fi
   cargo_cache:
     folder: $HOME/.cargo/registry
     fingerprint_script: cat Cargo.lock || echo ""
   test_script:
     - . $HOME/.cargo/env
-    - cargo test --all-features --target $TARGET
+    - cargo +$TEST_VERSION test --all-features --target $TARGET
   bench_script:
     - . $HOME/.cargo/env
     - if [ "$VERSION" = "nightly" ]; then
-      cargo test --all-features --benches
+      cargo +$TEST_VERSION test --all-features --benches --target $TARGET
     - fi
   doc_script:
     - . $HOME/.cargo/env

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,5 @@ serde_json = { version="1.0", optional=true }
 thiserror = "1.0.32"
 
 [dev-dependencies]
-cli-table = { version="0.4", default-features=false, features=["derive"] }
+cli-table = { version="0.5", default-features=false, features=["derive"] }
 pretty_env_logger = "0.5"

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -49,15 +49,16 @@ fn test_serializing_jail() {
     }
 }
 
+/// Test that rctl limits are actually effective, by limiting a process's Wallclock.
 #[test]
-fn test_rctl_yes() {
+fn test_rctl_limit() {
     if !rctl::State::check().is_enabled() {
         // If we don't have RCTL, let's just skip this test.
         return;
     }
 
     let running = StoppedJail::new("/")
-        .name("testjail_rctl_yes")
+        .name("testjail_rctl_limit")
         .limit(
             rctl::Resource::Wallclock,
             rctl::Limit::amount(1),
@@ -67,10 +68,11 @@ fn test_rctl_yes() {
         .expect("Could not start Jail");
 
     // this should hang until killed by the limit
-    let output = Command::new("/usr/bin/yes")
+    let output = Command::new("/bin/sleep")
+        .arg("10")
         .jail(&running)
         .output()
-        .expect("Failed to start yes command");
+        .expect("Failed to start sleep command");
 
     assert!(output.status.code().is_none());
     assert!(output.status.signal() == Some(9));


### PR DESCRIPTION
* Fix an intermittent test failure in test_rctl_yes
* Test i686 on nightly again
* Test on FreeBSD 14.2 instead of 14.1
* Stop running tests on MSRV
* Raise the cli_table dev-dependency to 0.5

See individual commit messages for full details.