### PR TITLE
Clippy cleanup

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -119,7 +119,7 @@ fn iterate_100_jails(b: &mut Bencher) {
     let mut running_jails: Vec<RunningJail> = (1..100)
         .map(|i| {
             StoppedJail::new("/rescue")
-                .name(format!("benchjail_iterate_{}", i))
+                .name(format!("benchjail_iterate_{i}"))
                 .start()
                 .expect("failed to start jail")
         })

--- a/examples/jls.rs
+++ b/examples/jls.rs
@@ -26,7 +26,7 @@ fn main() {
             .ips()
             .unwrap()
             .iter()
-            .map(|ip| format!("{}", ip))
+            .map(|ip| format!("{ip}"))
             .collect();
 
         let jail = Jail {

--- a/examples/resource_accounting.rs
+++ b/examples/resource_accounting.rs
@@ -15,7 +15,7 @@ fn main() {
     println!("created new jail with JID {}", running.jid);
 
     println!("Let's run a command that burns CPU cycles in the jail!");
-    Command::new("/usr/bin/yes")
+    let mut cmd = Command::new("/usr/bin/yes")
         .jail(&running)
         .stdout(Stdio::null())
         .spawn()
@@ -24,16 +24,17 @@ fn main() {
     for _ in 1..10 {
         thread::sleep(time::Duration::from_millis(1000));
         match running.racct_statistics() {
-            Ok(stats) => println!("Resource accounting statistics: {:#?}", stats),
+            Ok(stats) => println!("Resource accounting statistics: {stats:#?}"),
             Err(jail::JailError::RctlError(rctl::Error::InvalidKernelState(state))) => {
-                println!("Resource accounting is reported as {}", state)
+                println!("Resource accounting is reported as {state}")
             }
             Err(e) => {
-                println!("Other Error: {}", e);
+                println!("Other Error: {e}");
                 break;
             }
         };
     }
 
     running.kill().expect("Could not kill jail");
+    cmd.wait().unwrap();
 }

--- a/examples/serialize.rs
+++ b/examples/serialize.rs
@@ -41,7 +41,7 @@ fn main() {
 
     let serialized = serde_json::to_string_pretty(&stopped).expect("Failed to serialize jail");
 
-    println!("{}", serialized);
+    println!("{serialized}");
 }
 
 #[cfg(not(feature = "serialize"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl Jail {
                 .params
                 .get(name)
                 .ok_or_else(|| JailError::NoSuchParameter(name.into()))
-                .map(|x| x.clone()),
+                .cloned()
         }
     }
 

--- a/src/param.rs
+++ b/src/param.rs
@@ -257,7 +257,7 @@ impl Value {
         let mut bytes: Vec<u8> = vec![];
 
         // Some conversions are identity on 64 bit, but not on 32 bit and vice versa
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
+        #[allow(clippy::useless_conversion)]
         match self {
             Value::String(s) => {
                 bytes = CString::new(s.as_str())
@@ -288,7 +288,7 @@ impl Value {
             }
             Value::Ipv4Addrs(addrs) => {
                 for addr in addrs {
-                    let s_addr = nix::sys::socket::Ipv4Addr::from_std(&addr).0.s_addr;
+                    let s_addr = nix::sys::socket::Ipv4Addr::from_std(addr).0.s_addr;
                     let host_u32 = u32::from_be(s_addr);
                     bytes
                         .write_u32::<NetworkEndian>(host_u32)
@@ -422,7 +422,7 @@ impl Value {
     pub fn unpack_u64(self) -> Result<u64, JailError> {
         trace!("Value::unpack_u64({:?})", self);
         // Some conversions are identity on 64 bit, but not on 32 bit and vice versa
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
+        #[allow(clippy::useless_conversion)]
         match self {
             Value::U64(v) => Ok(v),
             Value::U32(v) => Ok(v.into()),
@@ -460,7 +460,7 @@ impl Value {
     pub fn unpack_i64(self) -> Result<i64, JailError> {
         trace!("Value::unpack_i64({:?})", self);
         // Some conversions are identity on 64 bit, but not on 32 bit and vice versa
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::useless_conversion))]
+        #[allow(clippy::useless_conversion)]
         match self {
             Value::S64(v) => Ok(v),
             Value::S32(v) => Ok(v.into()),
@@ -481,7 +481,7 @@ impl Value {
 fn info(name: &str) -> Result<(CtlType, CtlFlags, usize), JailError> {
     trace!("info({:?})", name);
     // Get parameter type
-    let ctlname = format!("security.jail.param.{}", name);
+    let ctlname = format!("security.jail.param.{name}");
 
     let ctl = Ctl::new(&ctlname).map_err(|_| JailError::NoSuchParameter(name.to_string()))?;
 
@@ -613,7 +613,7 @@ pub fn get(jid: i32, name: &str) -> Result<Value, JailError> {
 
     let jid = unsafe {
         libc::jail_get(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::empty().bits(),
         )
@@ -671,7 +671,7 @@ pub fn get(jid: i32, name: &str) -> Result<Value, JailError> {
                  retrieved is not a multiple of the size of in_addr."
             );
 
-            #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+            //#[allow(clippy::cast_ptr_alignment)]
             let ips: Vec<net::Ipv4Addr> =
                 unsafe { slice::from_raw_parts(value.as_ptr() as *const libc::in_addr, count) }
                     .iter()
@@ -694,7 +694,7 @@ pub fn get(jid: i32, name: &str) -> Result<Value, JailError> {
                  retrieved is not a multiple of the size of in_addr."
             );
 
-            #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
+            //#[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
             let ips: Vec<net::Ipv6Addr> =
                 unsafe { slice::from_raw_parts(value.as_ptr() as *const libc::in6_addr, count) }
                     .iter()
@@ -780,7 +780,7 @@ pub fn set(jid: i32, name: &str, value: Value) -> Result<(), JailError> {
 
     let jid = unsafe {
         libc::jail_set(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::UPDATE.bits(),
         )
@@ -824,7 +824,7 @@ pub fn get_all(jid: i32) -> Result<HashMap<String, Value>, JailError> {
     // If we have individual filters on each of these, we'll end up with a
     // very large type_length_limit. We can quickly check names against a vec
     // to avoid that.
-    let filtered_names = vec![
+    let filtered_names = [
         // The following parameters are dynamic
         "jid",
         "dying",

--- a/src/running.rs
+++ b/src/running.rs
@@ -2,7 +2,7 @@ use crate::{param, sys, JailError, StoppedJail};
 use log::trace;
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use std::io::{Error, ErrorKind};
+use std::io::Error;
 use std::net;
 use std::path;
 
@@ -491,8 +491,7 @@ impl RunningJail {
         match ret {
             0 => Ok(()),
             -1 => Err(Error::last_os_error()),
-            _ => Err(Error::new(
-                ErrorKind::Other,
+            _ => Err(Error::other(
                 "invalid return value from jail_attach",
             )),
         }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -104,7 +104,7 @@ pub fn jail_create(
 
     let jid = unsafe {
         libc::jail_set(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::CREATE.bits,
         )
@@ -137,7 +137,7 @@ pub fn jail_exists(jid: i32) -> bool {
 
     let retjid = unsafe {
         libc::jail_get(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::empty().bits,
         )
@@ -162,7 +162,7 @@ pub fn jail_clearpersist(jid: i32) -> Result<(), JailError> {
 
     let jid = unsafe {
         libc::jail_set(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::UPDATE.bits,
         )
@@ -204,7 +204,7 @@ pub fn jail_getid(name: &str) -> Result<i32, JailError> {
 
     let jid = unsafe {
         libc::jail_get(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::empty().bits,
         )
@@ -239,7 +239,7 @@ pub fn jail_nextjid(lastjid: i32) -> Result<i32, JailError> {
 
     let jid = unsafe {
         libc::jail_get(
-            jiov[..].as_mut_ptr() as *mut libc::iovec,
+            jiov[..].as_mut_ptr(),
             jiov.len() as u32,
             JailFlags::empty().bits,
         )

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,7 +2,6 @@ use crate::param;
 use crate::process::Jailed;
 use crate::running::RunningJail;
 use crate::stopped::StoppedJail;
-use rctl;
 use std::os::unix::process::ExitStatusExt;
 use std::process::Command;
 
@@ -73,10 +72,10 @@ fn test_rctl_yes() {
         .output()
         .expect("Failed to start yes command");
 
-    assert!(output.status.code() == None);
+    assert!(output.status.code().is_none());
     assert!(output.status.signal() == Some(9));
 
-    println!("{:?}", output);
+    println!("{output:?}");
 
     running.stop().expect("Could not stop Jail");
 }


### PR DESCRIPTION
* clippy::deprecated_clippy_cfg_attr
* clippy::unnecessary_cast
* clippy::io_other_error
* clippy::uninlined_format_args
* clippy::partialeq_to_none
* clippy::useless_vec
* clippy::single_component_path_imports
* clippy::needless_borrow
* clippy::map_clone
* clippy::zombie_processes