### PR TITLE
Fix the resource_accounting example after 4e776866609

### DIFF
--- a/examples/resource_accounting.rs
+++ b/examples/resource_accounting.rs
@@ -15,13 +15,11 @@ fn main() {
     println!("created new jail with JID {}", running.jid);
 
     println!("Let's run a command that burns CPU cycles in the jail!");
-    Command::new("/usr/bin/true")
+    let mut cmd = Command::new("/usr/bin/yes")
         .jail(&running)
         .stdout(Stdio::null())
         .spawn()
-        .expect("Failed to execute command in jail")
-        .wait()
-        .expect("/usr/bin/true failed?");
+        .expect("Failed to execute command in jail");
 
     for _ in 1..10 {
         thread::sleep(time::Duration::from_millis(1000));
@@ -38,4 +36,5 @@ fn main() {
     }
 
     running.kill().expect("Could not kill jail");
+    cmd.wait().expect("/usr/bin/yes failed?");
 }


### PR DESCRIPTION
In that revision, in my rush to fix clippy lints, I accidentally subverted the purpose of the example.