### PR TITLE
Update strum and strum_macros to 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ log="0.4.8"
 sysctl = ">=0.5.4, < 0.7"
 nix = { version = "0.29.0", default-features = false, features = ["socket"] }
 rctl = "0.3.0"
-strum_macros = "0.26.0"
+strum = "0.27.0"
+strum_macros = "0.27.0"
 serde = { version="1.0.113", features = ["derive"], optional=true}
 serde_json = { version="1.0", optional=true }
 thiserror = "1.0.32"


### PR DESCRIPTION
So downstream consumers can use the latest version.