### PR TITLE
Update multiple dependencies

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,52 +7,59 @@ setup: &SETUP
     - fetch https://sh.rustup.rs -o rustup.sh
     - sh rustup.sh -y --profile=minimal --default-toolchain $VERSION
     - . $HOME/.cargo/env
-    - rustup toolchain install --profile=minimal $TEST_VERSION
 
 task:
   env:
     HOME: /tmp  # cargo cache needs it
     TARGET: x86_64-unknown-freebsd
     VERSION: nightly
-    TEST_VERSION: nightly
   matrix:
-    - name: FreeBSD 13 amd64 nightly
+    - name: FreeBSD 15 amd64 nightly
       freebsd_instance:
-        image: freebsd-13-4-release-amd64
+        image: freebsd-15-0-alpha3-amd64-ufs
     - name: FreeBSD 14 amd64 nightly
       freebsd_instance:
-        image: freebsd-14-2-release-amd64-ufs
-    - name: FreeBSD 14 amd64 stable
-      env:
-        VERSION: 1.80.0
-        TEST_VERSION: 1.85.0
-      freebsd_instance:
-        image: freebsd-14-2-release-amd64-ufs
+        image: freebsd-14-3-release-amd64-ufs
     - name: FreeBSD 14 i686 nightly
       # Test i686 FreeBSD in 32-bit emulation on a 64-bit host.
       env:
         TARGET: i686-unknown-freebsd
       freebsd_instance:
-        image: freebsd-14-2-release-amd64-ufs
+        image: freebsd-14-3-release-amd64-ufs
   << : *SETUP
   extra_setup_script:
     - . $HOME/.cargo/env
     - if [ "$TARGET" = "i686-unknown-freebsd" ]; then rustup target add --toolchain $VERSION i686-unknown-freebsd; fi
-    - if [ "$TARGET" = "i686-unknown-freebsd" ]; then rustup target add --toolchain $TEST_VERSION i686-unknown-freebsd; fi
   cargo_cache:
     folder: $HOME/.cargo/registry
     fingerprint_script: cat Cargo.lock || echo ""
   test_script:
     - . $HOME/.cargo/env
-    - cargo +$TEST_VERSION test --all-features --target $TARGET
+    - cargo +$VERSION test --all-features --target $TARGET
   bench_script:
     - . $HOME/.cargo/env
-    - if [ "$VERSION" = "nightly" ]; then
-      cargo +$TEST_VERSION test --all-features --benches --target $TARGET
-    - fi
+    - cargo +$VERSION test --all-features --benches --target $TARGET
   doc_script:
     - . $HOME/.cargo/env
-    - cargo doc --target $TARGET --no-deps --all-features
+    - cargo +$VERSION doc --target $TARGET --no-deps --all-features
+  before_cache_script: rm -rf $HOME/.cargo/registry/index 
+
+task:
+  name: FreeBSD 14 amd64 stable
+  env:
+    VERSION: 1.80.0
+  freebsd_instance:
+    image: freebsd-14-3-release-amd64-ufs
+  << : *SETUP
+  cargo_cache:
+    folder: $HOME/.cargo/registry
+    fingerprint_script: cat Cargo.lock || echo ""
+  msrv_script:
+    - . $HOME/.cargo/env
+    # For the MSRV, must downgrade some deps
+    - cargo update -p sysctl --precise 0.6.0
+    - cargo update -p rctl --precise 0.3.0
+    - cargo +$VERSION check --all-features
   before_cache_script: rm -rf $HOME/.cargo/registry/index 
 
 # Stuff that doesn't need to be repeated for each target, env, and toolchain
@@ -62,7 +69,7 @@ lint_task:
     HOME: /tmp  # cargo cache needs it
     VERSION: nightly
   freebsd_instance:
-    image: freebsd-14-2-release-amd64-ufs
+    image: freebsd-14-3-release-amd64-ufs
   << : *SETUP
   extra_setup_script:
     - . $HOME/.cargo/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
+## [Unreleased] - ReleaseDate
+
 ### Changed
 - Broadened the dependency spec on Nix, for better compatibility with
   downstream consumers that have various requirements. (#157)
+
+- Broadened the dependency spec on rctl, sysctl, and thiserror, for better
+  compatibility with downstream consumers that have various requirements.
+  (#166)
 
 ## [0.3.0] - 2024-10-01
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,14 +39,14 @@ bitflags = "2.6.0"
 byteorder = "1.4.3"
 libc = "0.2.155"
 log="0.4.8"
-sysctl = ">=0.5.4, < 0.7"
+sysctl = ">=0.5.4, < 0.8"
 nix = { version = ">=0.28.0, < 0.31", default-features = false, features = ["socket"] }
-rctl = "0.3.0"
+rctl = ">=0.3.0, <0.5.0"
 strum = "0.27.0"
 strum_macros = "0.27.0"
 serde = { version="1.0.113", features = ["derive"], optional=true}
 serde_json = { version="1.0", optional=true }
-thiserror = "1.0.32"
+thiserror = ">=1.0.32, <3.0"
 
 [dev-dependencies]
 cli-table = { version="0.5", default-features=false, features=["derive"] }


### PR DESCRIPTION
Broaden the allowed version range of rctl, sysctl, and thiserror, to reduce duplicate dependencies in downstream crates.